### PR TITLE
Introducing Support for ReDoc's x-logo

### DIFF
--- a/src/Info.php
+++ b/src/Info.php
@@ -91,7 +91,7 @@ class Info implements Arrayable
      */
     public function contact(Contact $contact) : Info
     {
-        $this->contact = $contact->toArray();
+        $this->contact = $contact;
 
         return $this;
     }

--- a/src/Info.php
+++ b/src/Info.php
@@ -97,7 +97,7 @@ class Info implements Arrayable
     }
 
     /**
-     * The logo information for the exposed API.
+     * The logo for the exposed API.
      *
      * @param Logo $logo
      * @return Info

--- a/src/Info.php
+++ b/src/Info.php
@@ -25,6 +25,11 @@ use Illuminate\Contracts\Support\Arrayable;
  *      "name": "Apache 2.0",
  *      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
  *  },
+ *  "x-logo": {
+ *      "url": "http://www.example.com/assets/img/logo.png",
+ *      "backgroundColor": "#000000",
+ *      "altText": "Examplef"
+ *  },
  *  "version": "1.0.1"
  * }
  */
@@ -37,6 +42,7 @@ class Info implements Arrayable
     protected $description;
     protected $termsOfService;
     protected $contact;
+    protected $x_logo;
 
     /**
      * Info constructor.
@@ -85,7 +91,20 @@ class Info implements Arrayable
      */
     public function contact(Contact $contact) : Info
     {
-        $this->contact = $contact;
+        $this->contact = $contact->toArray();
+
+        return $this;
+    }
+
+    /**
+     * The logo information for the exposed API.
+     *
+     * @param Logo $logo
+     * @return Info
+     */
+    public function logo(Logo $logo) : Info
+    {
+        $this->x_logo = $logo;
 
         return $this;
     }

--- a/src/Logo.php
+++ b/src/Logo.php
@@ -15,9 +15,7 @@ class Logo implements Arrayable
     use ToArray;
 
     protected $url;
-
     protected $backgroundColor;
-
     protected $altText;
 
     /**

--- a/src/Logo.php
+++ b/src/Logo.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace PandaLeague\OpenApiBuilder;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * Logo for the exposed API.
+ *
+ * Class Logo
+ * @package PandaLeague\OpenApiBuilder
+ */
+class Logo implements Arrayable
+{
+    use ToArray;
+
+    protected $url;
+
+    protected $backgroundColor;
+
+    protected $altText;
+
+    /**
+     * The URL pointing to the logo. MUST be in the format of a URL.
+     *
+     * @param string $url
+     * @return Logo
+     */
+    public function url(string $url) :  Logo
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * The background color. MUST be in hex format.
+     *
+     * @param string $backgroundColor
+     * @return Logo
+     */
+    public function backgroundColor(string $backgroundColor) :  Logo
+    {
+        $this->backgroundColor = $backgroundColor;
+
+        return $this;
+    }
+
+    /**
+     * The alt text.
+     *
+     * @param string $altText
+     * @return Logo
+     */
+    public function altText(string $altText) :  Logo
+    {
+        $this->altText = $altText;
+
+        return $this;
+    }
+}

--- a/src/ToArray.php
+++ b/src/ToArray.php
@@ -20,29 +20,29 @@ trait ToArray
             $value = $property->getValue($this);
 
             if ($value instanceof Schema) {
-                $data[$property->getName()] = $value->schema();
+                $data[$name] = $value->schema();
             } elseif(is_object($value)) {
                 if ($value instanceof Arrayable) {
                     $value = $value->toArray();
-                    $data[$property->getName()] = $value;
+                    $data[$name] = $value;
                 }
             }
             elseif (is_array($value)) {
                 foreach ($value as $key => $v) {
                     if ($v instanceof Schema) {
-                        $data[$property->getName()][$key] = $v->schema();
+                        $data[$name][$key] = $v->schema();
                     } elseif(is_object($v)) {
                         if ($v instanceof Arrayable) {
                             $v = $v->toArray();
-                            $data[$property->getName()][$key] = $v;
+                            $data[$name][$key] = $v;
                         }
                     } elseif (!is_array($v)) {
-                        $data[$property->getName()][$key] = $v;
+                        $data[$name][$key] = $v;
                     }
                 }
             }
             elseif (!is_null($value)) {
-                $data[$property->getName()] = $value;
+                $data[$name] = $value;
             }
         }
 

--- a/src/ToArray.php
+++ b/src/ToArray.php
@@ -14,6 +14,8 @@ trait ToArray
 
         foreach ($properties as $property)
         {
+            $name = str_replace('_', '-', $property->getName());
+
             $property->setAccessible(true);
             $value = $property->getValue($this);
 


### PR DESCRIPTION
This PR includes the support for `x-logo` so that we can include branding elements to ReDoc.

```
"x-logo": {
      "url": "https://redocly.github.io/redoc/redoc-logo.png",
      "backgroundColor": "#FFFFFF",
      "altText": "Redoc logo"
}
```

